### PR TITLE
Updated pushrocks to version 1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "mailgun-send": "0.0.3",
     "marked": "^0.3.5",
     "merge-stream": "^1.0.0",
-    "pushrocks": "1.0.3",
+    "pushrocks": "1.0.4",
     "request": "^2.60.0",
     "require-dir": "^0.3.0",
     "require-reload": "^0.2.2",


### PR DESCRIPTION
:rocket:

pushrocks just published version 1.0.4, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 8 commits (ahead by 8, behind by 0).

- [30867da](https://github.com/pushrocks/pushrocks/commit/30867da714a20ecd78b0dedf60dad1456af2885d): 1.0.4
- [5cb327f](https://github.com/pushrocks/pushrocks/commit/5cb327fda898816a82cccd430260c31029a7edd5): cleanup
- [2d809db](https://github.com/pushrocks/pushrocks/commit/2d809db5b294c3bef64490a553a1772b27fc0019): Merge branch 'master' of github.com:pushrocks/pushrocks
- [457e76e](https://github.com/pushrocks/pushrocks/commit/457e76e1eb38a013fd34ad9ac38a9b10dc202f06): added scripts
- [75416d3](https://github.com/pushrocks/pushrocks/commit/75416d31f23c861ebeb1af37dd90e990cb4881bc): Merge pull request #2 from pushrocks/greenkeeper-beautylog-0.0.12
- [1336cf4](https://github.com/pushrocks/pushrocks/commit/1336cf41881b6a6a3efd4a3b539dbe7cf0eba912): chore(package): update beautylog to version 0.0.12
- [465eab9](https://github.com/pushrocks/pushrocks/commit/465eab9389150400370dc5b571e1db86f7459228): commit package.json
- [7e21259](https://github.com/pushrocks/pushrocks/commit/7e212595230d35191882052f1000fb4413a8e386): chore(package): pin dependencies

See the [full diff](https://github.com/pushrocks/pushrocks/compare/2a3e687126734c1c8b16d8daeb4fb5a7c5d8fa52...30867da714a20ecd78b0dedf60dad1456af2885d).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>