### PR TITLE
Updated pushrocks to version 1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "mailgun-send": "0.0.3",
     "marked": "^0.3.5",
     "merge-stream": "^1.0.0",
-    "pushrocks": "1.0.4",
+    "pushrocks": "1.0.5",
     "request": "^2.60.0",
     "require-dir": "^0.3.0",
     "require-reload": "^0.2.2",


### PR DESCRIPTION
:rocket:

pushrocks just published version 1.0.5, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 1 commits (ahead by 1, behind by 0).

- [25d6417](https://github.com/pushrocks/pushrocks/commit/25d641703f358358280f46aaebe32be1ca1745b5): 1.0.5

See the [full diff](https://github.com/pushrocks/pushrocks/compare/30867da714a20ecd78b0dedf60dad1456af2885d...25d641703f358358280f46aaebe32be1ca1745b5).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>