### PR TITLE
Updated pushrocks to version 1.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "mailgun-send": "0.0.3",
     "marked": "^0.3.5",
     "merge-stream": "^1.0.0",
-    "pushrocks": "1.0.5",
+    "pushrocks": "1.0.6",
     "request": "^2.60.0",
     "require-dir": "^0.3.0",
     "require-reload": "^0.2.2",


### PR DESCRIPTION
:rocket:

pushrocks just published version 1.0.6, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 2 commits (ahead by 2, behind by 0).

- [fb55cf0](https://github.com/pushrocks/pushrocks/commit/fb55cf0a76cd15b77fda5487eb9aa80d570930a6): 1.0.6
- [59ce086](https://github.com/pushrocks/pushrocks/commit/59ce08628fcdc42dc83bd100779a44e7af509b6e): added smarcli

See the [full diff](https://github.com/pushrocks/pushrocks/compare/25d641703f358358280f46aaebe32be1ca1745b5...fb55cf0a76cd15b77fda5487eb9aa80d570930a6).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>