### PR TITLE
Updated pushrocks to version 1.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "mailgun-send": "0.0.3",
     "marked": "^0.3.5",
     "merge-stream": "^1.0.0",
-    "pushrocks": "1.0.6",
+    "pushrocks": "1.0.7",
     "request": "^2.60.0",
     "require-dir": "^0.3.0",
     "require-reload": "^0.2.2",


### PR DESCRIPTION
:rocket:

pushrocks just published version 1.0.7, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 3 commits (ahead by 3, behind by 0).

- [04e7c3c](https://github.com/pushrocks/pushrocks/commit/04e7c3c97eece363d21855d9fdf1926b044fc44a): 1.0.7
- [fcf50b4](https://github.com/pushrocks/pushrocks/commit/fcf50b4de96fa98fb17a1ea0cd41cea9b7255557): Merge pull request #3 from pushrocks/greenkeeper-smartcli-0.0.5
- [8944f01](https://github.com/pushrocks/pushrocks/commit/8944f01d0e2a7f9c472ac71db596da8b01bb7279): chore(package): update smartcli to version 0.0.5

See the [full diff](https://github.com/pushrocks/pushrocks/compare/fb55cf0a76cd15b77fda5487eb9aa80d570930a6...04e7c3c97eece363d21855d9fdf1926b044fc44a).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>