### PR TITLE
Updated jade-doc to version 1.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "gulp-umbrella": "1.0.6",
     "gulp-util": "^3.0.6",
     "jade": "^1.11.0",
-    "jade-doc": "1.2.2",
+    "jade-doc": "1.2.3",
     "mailgun-send": "0.0.3",
     "marked": "^0.3.5",
     "merge-stream": "^1.0.0",


### PR DESCRIPTION
:rocket:

jade-doc just published version 1.2.3, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 2 commits (ahead by 2, behind by 0).

- [d100f68](https://github.com/Aratramba/jade-doc/commit/d100f68bcde6fecbb889c99b19372a1357d553b3): refer to index instead of ./
- [5132af7](https://github.com/Aratramba/jade-doc/commit/5132af78d311ac5b720d825cb36f42c90c564017): update readme

See the [full diff](https://github.com/Aratramba/jade-doc/compare/644ccf7cbe3198e1d4f0f3437b63ee3aff6c6271...d100f68bcde6fecbb889c99b19372a1357d553b3).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>